### PR TITLE
Page event

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,9 @@ module.exports = function(grunt) {
       standalone: {
         command: 'component build --standalone ListPagination -n list.pagination.standalone'
       },
+      mkdir: {
+        command: 'mkdir -p dist'
+      },
       move: {
         command: 'mv build/list.pagination.standalone.js dist/list.pagination.js'
       },
@@ -88,9 +91,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-mocha');
 
-  grunt.registerTask('mkdir', function() { grunt.file.mkdir("dist"); });
   grunt.registerTask('default', ['jshint:code', 'jshint:tests', 'shell:install', 'shell:build', 'mocha']);
-  grunt.registerTask('dist', ['default', 'shell:standalone', 'mkdir', 'shell:move', 'uglify']);
+  grunt.registerTask('dist', ['default', 'shell:standalone', 'shell:mkdir', 'shell:move', 'uglify']);
   grunt.registerTask('clean', ['shell:remove']);
 
   grunt.registerTask('test', ['mocha']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,9 +28,6 @@ module.exports = function(grunt) {
       standalone: {
         command: 'component build --standalone ListPagination -n list.pagination.standalone'
       },
-      mkdir: {
-        command: 'mkdir -p dist'
-      },
       move: {
         command: 'mv build/list.pagination.standalone.js dist/list.pagination.js'
       },
@@ -91,8 +88,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-mocha');
 
+  grunt.registerTask('mkdir', function() { grunt.file.mkdir("dist"); });
   grunt.registerTask('default', ['jshint:code', 'jshint:tests', 'shell:install', 'shell:build', 'mocha']);
-  grunt.registerTask('dist', ['default', 'shell:standalone', 'shell:mkdir', 'shell:move', 'uglify']);
+  grunt.registerTask('dist', ['default', 'shell:standalone', 'mkdir', 'shell:move', 'uglify']);
   grunt.registerTask('clean', ['shell:remove']);
 
   grunt.registerTask('test', ['mocha']);

--- a/index.js
+++ b/index.js
@@ -75,13 +75,19 @@ module.exports = function(options) {
 
     var addEvent = function(elm, i, page) {
        events.bind(elm, 'click', function() {
+           list.trigger('pageChangeStart');
            list.show((i-1)*page + 1, page);
+           list.trigger('pageChangeComplete');
        });
     };
 
     return {
         init: function(parentList) {
             list = parentList;
+
+            list.handlers.pageChangeStart = list.handlers.pageChangeStart || [];
+            list.handlers.pageChangeComplete = list.handlers.pageChangeComplete || [];
+
             pagingList = new List(list.listContainer.id, {
                 listClass: options.paginationClass || 'pagination',
                 item: "<li><a class='page' href='javascript:function Z(){Z=\"\"}Z()'></a></li>",

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,7 @@
     <script src="test.default.js"></script>
     <script src="test.custom.js"></script>
     <script src="test.custom2.js"></script>
+    <script src="test.on.js"></script>
 
     <script>
         if (navigator.userAgent.indexOf('PhantomJS') < 0) {

--- a/test/test.on.js
+++ b/test/test.on.js
@@ -1,0 +1,40 @@
+describe('On', function() {
+
+    var list,
+        itemHTML,
+        pagination;
+
+    before(function() {
+        itemHTML = fixture.list(['name'])
+        list = new List('list', {
+            valueNames: ['name'],
+            item: itemHTML,
+            page: 2,
+            plugins: [
+                ListPagination({})
+            ]
+        }, fixture.all);
+
+        pagination = $('.pagination');
+        page1 = pagination.find('.page')[0]
+    });
+
+    after(function() {
+        fixture.removeList();
+    });
+
+    describe('changePage', function() {
+        it('should be triggered before and after page change', function(done) {
+            var done1 = false;
+            list.on('pageChangeStart', function(list) {
+                done1 = true;
+            });
+            list.on('pageChangeComplete', function(list) {
+                if (done1) {
+                    done();
+                }
+            });
+            page1.click();
+        });
+    });
+});

--- a/test/test.on.js
+++ b/test/test.on.js
@@ -23,7 +23,7 @@ describe('On', function() {
         fixture.removeList();
     });
 
-    describe('changePage', function() {
+    describe('pageChange', function() {
         it('should be triggered before and after page change', function(done) {
             var done1 = false;
             list.on('pageChangeStart', function(list) {


### PR DESCRIPTION
Adds start and complete events to page changes when using the pagination addon.  The only event currently fired on a page change is `updated`, but that fires too often to be useful for triggering code that should only be run once per page change.  The events and handlers are added in the addon so that they do not impact anyone not using pagination.